### PR TITLE
made feed reader errors more descriptive

### DIFF
--- a/backend/rss/feed_reader.py
+++ b/backend/rss/feed_reader.py
@@ -15,7 +15,7 @@ def get_feeds(location):
     for source in rss_sources:
         feed = feedparser.parse(source.url)
         if feed.bozo:
-            print("Error reading feed: " + str(feed.bozo_exception))
+            print("Error from " + source.url + ": " + str(feed.bozo_exception))
             continue
         else:
             feeds['entries'].extend(feed.entries)


### PR DESCRIPTION
added a line to be more descriptive when an error occurs during rss source parsing. the message will now say which source is causing the error. could be helpful in debugging